### PR TITLE
Document legacy status of Replicator-Old mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# Replicator-Old
-past replicator
+# Replicator (Legacy Edition)
+
+This repository stores an **old, archived build** of the Replicator mod. It is preserved solely for historical reference and for players who may want to explore how the project looked in the past.
+
+## Important Notice
+
+- This codebase represents a legacy snapshot of the mod and **will not receive updates, fixes, or new features**.
+- Issues and pull requests will not be monitored. Please do not expect maintenance or support.
+- Modern versions of the game may no longer be compatible with this build.
+
+## About the Mod
+
+Replicator introduces automation-focused mechanics inspired by self-replicating technology. Players can experiment with advanced production chains, unique resources, and custom textures tailored to the original release period captured here.
+
+## Historical Context
+
+This archive corresponds to the "Replicator-Old" branch that pre-dates subsequent rewrites. Mechanics, balance, and art assets reflect the standards of that time. Some references in the `Defs`, `Textures`, `Languages`, and `1.6` directories may differ significantly from newer editions.
+
+## Getting Started
+
+If you still wish to try this legacy version:
+
+1. Back up your current saves and mods.
+2. Copy the contents of this repository into your game's mods directory.
+3. Enable the mod in-game, understanding that compatibility is not guaranteed.
+
+## No Maintenance Guarantee
+
+This repository is **frozen**. Any issues encountered are inherent to this historical build. For maintained releases or community forks, seek out more recent repositories or official distribution channels.
+
+## License
+
+Refer to the original license included with the project for usage terms. If no license is present, assume all rights are reserved by the original authors.
+


### PR DESCRIPTION
## Summary
- expand the README to clarify that the repository stores an archived legacy build
- add context, usage guidance, and an explicit notice that no maintenance will occur

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e047b1eb78832bb02822fee8943781